### PR TITLE
plugin MVP, see README

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,17 @@
+steps:
+  - label: ":sparkles: Lint"
+    plugins:
+      - plugin-linter#v3.3.0:
+          id: cluster-secrets
+
+  - label: ":shell: Shellcheck"
+    plugins:
+      - shellcheck#v1.3.0:
+          files:
+            - hooks/**
+
+  - label: ":shell: Tests"
+    plugins:
+      - plugin-tester#v1.1.1:
+          folders:
+            - tests

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# cluster-secrets-buildkite-plugin
-A Buildkite plugin to fetch cluster secrets from Buildkite secrets
+# Cluster Secrets Buildkite Plugin
+
+A Buildkite plugin used to fetch secrets from [Buildkite Secrets](https://buildkite.com/docs/pipelines/buildkite-secrets),
+
+## Storing Secrets
+The plugin expects that secrets will be stored base64 encoded in a secret with the key "env", in the format KEY=value in Buildkite secrets:
+
+```shell
+Foo=bar
+SECRET_KEY=llamas
+COFFEE=more
+```
+
+You can create a secret in your Buildkite cluster(s) from the Buildkite UI following the instructions in the documentation [here](https://buildkite.com/docs/pipelines/buildkite-secrets#create-a-secret-using-the-buildkite-interface).
+
+## Examples
+
+### Default Configuration
+Add the plugin to your pipeline YAML to download. By default the plugin will fetch the secret with key `env`
+
+```yaml
+steps:
+    - command: build.sh
+      plugins:
+        - cluster-secrets#v0.1.0
+```
+
+### Custom Secret Key
+Alernatively, you can specify a custom key that will be fetched by the plugin, instead of the default `env`
+
+```yaml
+steps:
+    - command: build.sh
+      plugins:
+        - cluster-secrets#v0.1.0:
+            key: "llamas"
+```
+
+### Options
+Currently, the plugin supports a single configurable option
+#### `key` (optional, string)
+The key to fetch from Buildkite secrets, see [example](#custom-secret-key)
+
+## Testing
+You can run the tests using `docker-compose`:
+```bash
+docker compose run --rm tests
+```
+
+## License
+
+MIT (see [LICENSE](LICENSE))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+services:
+  tests:
+    image: buildkite/plugin-tester:v4.1.1
+    volumes:
+      - .:/plugin

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# downloads the secret by provided key using the buildkite-agent secret command
+downloadSecret() {
+    local key=$1
+
+    if ! secret=$(buildkite-agent secret get "${key}"); then
+        echo "⚠️ An error occurred"
+        exit 1
+    fi
+    echo "${secret}"
+}
+
+# decodes a base64 encoded secret, expects decoded secret to be in the format KEY=value:
+# FOO=BAR
+# BAR=BAZ
+decodeSecrets() {
+    local encoded_secret=$1
+    envscript=''
+
+    while IFS='=' read -r key value
+        do  
+            # Check if both key and value are non-empty
+            if [ -n "$key" ] && [ -n "$value" ]; then
+                # Update envscript
+                envscript+="${key}=${value}"$'\n'
+            fi
+    done <<< "$(echo "$encoded_secret" | base64 -d)"
+
+    echo "$envscript"
+}
+
+# decodes the base64 encoded secret passed in args, and exports the decoded secrets 
+# into the environment via the envscript variable
+processSecrets() {
+    local encoded_secret=$1
+    local envscript=''
+    
+    echo "~~~ 🔐 Fetching secrets from Buildkite secrets"
+
+    if ! envscript=$(decodeSecrets "${encoded_secret}"); then
+        echo "⚠️ Unable to decode secrets"
+        exit 1
+    fi
+
+    echo "Evaluating ${#envscript} bytes of env"
+    set -o allexport
+    eval "$envscript"
+    set +o allexport
+}
+
+# primarily used for debugging; The job log will show what env vars have changed after this hook is executed
+dumpEnvSecrets() {
+  if [[ "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
+    echo "~~~ 🔎 Environment variables that were set" >&2;
+    comm -13 <(echo "$env_before") <(env | sort) || true
+  fi
+}
+
+
+env_before="$(env | sort)" # used by 
+
+# If we are using a specific key we should download and evaluate it
+if [[ -n "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY:-}" ]]; then
+    secret=$(downloadSecret "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY}")
+    processSecrets "${secret}"
+else
+    # otherwise use the default env
+    secret=$(downloadSecret "env")
+    processSecrets "${secret}"
+fi
+
+dumpEnvSecrets

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,11 @@
+name: Cluster Secrets
+description: "A Buildkite plugin to fetch secrets from Buildkite secrets"
+author: "@buildkite-plugins"
+requirements:
+ - bash
+ - buildkite-agent
+configuration:
+  properties:
+    key:
+      type: string
+additionalProperties: false

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+  export BUILDKITE_PLUGIN_CLUSTER_SECRETS_DUMP_ENV=true
+}
+
+@test "Load default env from Buildkite secrets" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+}
+
+@test "Load env from custom key from Buildkite secrets" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY="llamas"
+
+    stub buildkite-agent "secret get llamas : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial "FOO=bar"
+
+}
+
+@test "If no key env found in Buildkite secrets the plugin fails" {
+   
+    stub buildkite-agent "secret get env : exit 1"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_failure
+}
+
+@test "If no custom key found in Buildkite secrets the plugin fails" {
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY="llamas"
+   
+    stub buildkite-agent "secret get llamas : exit 1"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_failure
+}


### PR DESCRIPTION
This is an MVP for the plugin to fetch cluster secrets from [Buildkite Secrets](https://buildkite.com/docs/pipelines/buildkite-secrets#create-a-secret-using-the-buildkite-interface).

It includes support for fetching a base64 encoded secret from either a custom `key` provided in the plugin config, or from the default key of `env`.