### PR TITLE
Add support for reading secrets one at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,32 @@
 A Buildkite plugin used to fetch secrets from [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets),
 
 ## Storing Secrets
-The plugin expects that secrets will be stored base64 encoded in a secret with the key "env", in the format KEY=value in Buildkite secrets:
+
+There are two options for storing and fetching secrets.
+
+You can create a secret in your Buildkite cluster(s) from the Buildkite UI following the instructions in the documentation [here](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets#create-a-secret-using-the-buildkite-interface).
+
+### One at a time
+
+Create a Buildkite secret for each variable that you need to store. Paste the value of the secret into buildkite.com directly.
+
+A `pipeline.yml` like this will read each secret out into a ENV variable:
+
+```yml
+steps:
+  - command: echo "The content of ANIMAL is \$ANIMAL"
+    plugins:
+      - cluster-secrets#v0.1.0:
+          parameters:
+            ANIMAL: llamas
+            FOO: bar
+```
+
+### Multiple
+
+Create a single Buildkite secret with one variable per line, encoded as base64 for storage. 
+
+For example, setting three variables looks like this in a file:
 
 ```shell
 Foo=bar
@@ -11,35 +36,32 @@ SECRET_KEY=llamas
 COFFEE=more
 ```
 
-You can create a secret in your Buildkite cluster(s) from the Buildkite UI following the instructions in the documentation [here](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets#create-a-secret-using-the-buildkite-interface).
+Then encode the file:
 
-## Examples
+```shell
+cat data.txt | base64
+```
 
-### Default Configuration
-Add the plugin to your pipeline YAML to download. By default the plugin will fetch the secret with key `env`
+Next, upload the base64 encoded data to buildkite.com in your browser with a
+key of your choosing - like `llamas`. The three secrets can be read into the
+job environment using a pipeline.yml like this:
 
 ```yaml
 steps:
-    - command: build.sh
-      plugins:
-        - cluster-secrets#v0.1.0
+  - command: build.sh
+    plugins:
+      - cluster-secrets#v0.1.0:
+          key: "llamas"
 ```
 
-### Custom Secret Key
-Alernatively, you can specify a custom key that will be fetched by the plugin, instead of the default `env`
+## Options
 
-```yaml
-steps:
-    - command: build.sh
-      plugins:
-        - cluster-secrets#v0.1.0:
-            key: "llamas"
-```
+### `key` (optional, string)
+The key to fetch multiple from Buildkite secrets
 
-### Options
-Currently, the plugin supports a single configurable option
-#### `key` (optional, string)
-The key to fetch from Buildkite secrets, see [example](#custom-secret-key)
+### `variables` (optional, object)
+Specify a dictionary of `key: value` pairs to inject as environment variables, where the key is the name of the
+environment variable to be set, and the value is the Buildkite Secret key.
 
 ## Testing
 You can run the tests using `docker-compose`:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ steps:
   - command: echo "The content of ANIMAL is \$ANIMAL"
     plugins:
       - cluster-secrets#v0.1.0:
-          parameters:
+          variables:
             ANIMAL: llamas
             FOO: bar
 ```

--- a/hooks/environment
+++ b/hooks/environment
@@ -43,14 +43,15 @@ processSecrets() {
         exit 1
     fi
 
-    echo "Evaluating ${#envscript} bytes of env"
+    # I don't think this echo is really needed outside of debugging during development
+    # so going to comment out for now and we can always re-evaluate it's usefulness later
+    # echo "Evaluating ${#envscript} bytes of env"
     set -o allexport
     eval "$envscript"
     set +o allexport
 }
 
 processVariables() {
-     echo "🔑 Fetching single variable secrets from Buildkite secrets"
   # Extract the environment variable keys and Buildkite secret paths.
   for param in ${!BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_*}; do
     key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -56,12 +56,12 @@ processVariables() {
   for param in ${!BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_*}; do
     key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"
     path="${!param}"
-
+    
     if ! value=$(buildkite-agent secret get "${path}"); then
         echo "⚠️ Unable to find secret at ${path}"
         exit 1
     else
-        export "${path}=${value}"
+        export "${key}=${value}"
     fi    
   done
 }

--- a/hooks/environment
+++ b/hooks/environment
@@ -6,7 +6,7 @@ downloadSecret() {
     local key=$1
 
     if ! secret=$(buildkite-agent secret get "${key}"); then
-        echo "not found"
+        echo "not found ${key}"
     else
         echo "${secret}"
     fi
@@ -38,8 +38,6 @@ processSecrets() {
     local encoded_secret=$1
     local envscript=''
 
-    echo "~~~ 🔐 Fetching secrets from Buildkite secrets"
-
     if ! envscript=$(decodeSecrets "${encoded_secret}"); then
         echo "⚠️ Unable to decode secrets"
         exit 1
@@ -52,6 +50,7 @@ processSecrets() {
 }
 
 processVariables() {
+     echo "🔑 Fetching single variable secrets from Buildkite secrets"
   # Extract the environment variable keys and Buildkite secret paths.
   for param in ${!BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_*}; do
     key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"
@@ -59,6 +58,7 @@ processVariables() {
 
     if ! value=$(buildkite-agent secret get "${path}"); then
         echo "⚠️ Unable to find secret at ${path}"
+        exit 1
     else
         export "${path}=${value}"
     fi    
@@ -76,11 +76,13 @@ dumpEnvSecrets() {
 
 env_before="$(env | sort)" # used by
 
+
+echo "🔐 Fetching env secrets from Buildkite secrets"
 # If we are using a specific key we should download and evaluate it
 if [[ -n "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}" ]]; then
     secret=$(downloadSecret "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}")
-    if [[ "${secret}" == "not found" ]]; then
-        echo "Unable to find secret at ${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}"
+    if [[ "${secret}" =~ "not found" ]]; then
+        echo "No secret found at ${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}"
     else
         processSecrets "${secret}"
     fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -6,10 +6,11 @@ downloadSecret() {
     local key=$1
 
     if ! secret=$(buildkite-agent secret get "${key}"); then
-        echo "⚠️ An error occurred"
-        exit 1
+        echo "not found"
+    else
+        echo "${secret}"
     fi
-    echo "${secret}"
+    
 }
 
 # decodes a base64 encoded secret, expects decoded secret to be in the format KEY=value:
@@ -56,9 +57,11 @@ processVariables() {
     key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"
     path="${!param}"
 
-    value=$(buildkite-agent secret get "${path}")
-
-    export "${path}=${value}"
+    if ! value=$(buildkite-agent secret get "${path}"); then
+        echo "⚠️ Unable to find secret at ${path}"
+    else
+        export "${path}=${value}"
+    fi    
   done
 }
 
@@ -74,9 +77,13 @@ dumpEnvSecrets() {
 env_before="$(env | sort)" # used by
 
 # If we are using a specific key we should download and evaluate it
-if [[ -n "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY:-}" ]]; then
-    secret=$(downloadSecret "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY}")
-    processSecrets "${secret}"
+if [[ -n "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}" ]]; then
+    secret=$(downloadSecret "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}")
+    if [[ "${secret}" == "not found" ]]; then
+        echo "Unable to find secret at ${BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV:-env}"
+    else
+        processSecrets "${secret}"
+    fi
 fi
 
 # Now download and set ENV specified using the `variables` plugin param

--- a/hooks/environment
+++ b/hooks/environment
@@ -58,7 +58,7 @@ processVariables() {
 
     value=$(buildkite-agent secret get "${path}")
 
-    export "${key}=${value}"
+    export "${path}=${value}"
   done
 }
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -20,7 +20,7 @@ decodeSecrets() {
     envscript=''
 
     while IFS='=' read -r key value
-        do  
+        do
             # Check if both key and value are non-empty
             if [ -n "$key" ] && [ -n "$value" ]; then
                 # Update envscript
@@ -31,12 +31,12 @@ decodeSecrets() {
     echo "$envscript"
 }
 
-# decodes the base64 encoded secret passed in args, and exports the decoded secrets 
+# decodes the base64 encoded secret passed in args, and exports the decoded secrets
 # into the environment via the envscript variable
 processSecrets() {
     local encoded_secret=$1
     local envscript=''
-    
+
     echo "~~~ 🔐 Fetching secrets from Buildkite secrets"
 
     if ! envscript=$(decodeSecrets "${encoded_secret}"); then
@@ -50,6 +50,18 @@ processSecrets() {
     set +o allexport
 }
 
+processVariables() {
+  # Extract the environment variable keys and Buildkite secret paths.
+  for param in ${!BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_*}; do
+    key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"
+    path="${!param}"
+
+    value=$(buildkite-agent secret get "${path}")
+
+    export "${key}=${value}"
+  done
+}
+
 # primarily used for debugging; The job log will show what env vars have changed after this hook is executed
 dumpEnvSecrets() {
   if [[ "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_DUMP_ENV:-}" =~ ^(true|1)$ ]] ; then
@@ -59,16 +71,15 @@ dumpEnvSecrets() {
 }
 
 
-env_before="$(env | sort)" # used by 
+env_before="$(env | sort)" # used by
 
 # If we are using a specific key we should download and evaluate it
 if [[ -n "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY:-}" ]]; then
     secret=$(downloadSecret "${BUILDKITE_PLUGIN_CLUSTER_SECRETS_KEY}")
     processSecrets "${secret}"
-else
-    # otherwise use the default env
-    secret=$(downloadSecret "env")
-    processSecrets "${secret}"
 fi
+
+# Now download and set ENV specified using the `variables` plugin param
+processVariables
 
 dumpEnvSecrets

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,7 +6,7 @@ requirements:
  - buildkite-agent
 configuration:
   properties:
-    key:
+    env:
       type: string
     variables:
       type: object

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,4 +8,6 @@ configuration:
   properties:
     key:
       type: string
+    variables:
+      type: object
 additionalProperties: false

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -77,18 +77,20 @@ setup() {
     run bash -c "$PWD/hooks/environment"
 
     assert_success
-    assert_output --partial "Unable to find secret at"
+    assert_output --partial "No secret found"
     unstub buildkite-agent
 }
 
-@test "If no custom key found in Buildkite secrets the plugin does nothing - but doesn't fail" {
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_ENV="llamas"
+@test "If no key from parameters found in Buildkite secrets the plugin fails" {
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_0="ANIMAL"
    
-    stub buildkite-agent "secret get llamas : echo 'not found'"
+    stub buildkite-agent \
+        "secret get env : echo 'not found'" \
+        "secret get ANIMAL : exit 1" 
 
     run bash -c "$PWD/hooks/environment"
 
-    assert_success
-    assert_output --partial "Unable to find secret at"
+    assert_failure
+    assert_output --partial "⚠️ Unable to find secret at"
     unstub buildkite-agent
 }

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 setup() {
   load "${BATS_PLUGIN_PATH}/load.bash"

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -36,11 +36,11 @@ setup() {
 
 @test "Download single variable from Buildkite secrets" {
     export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_0="ANIMAL"
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_ANIMAL="best"
     
     stub buildkite-agent \
         "secret get env : echo ${TESTDATA}" \
-        "secret get ANIMAL : echo llama"
+        "secret get best : echo llama"
 
     run bash -c "$PWD/hooks/environment"
 
@@ -51,15 +51,15 @@ setup() {
 
 @test "Download multiple variables from Buildkite secrets" {
     export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_0="ANIMAL"
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_1="COUNTRY"
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_2="FOOD"
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_ANIMAL="best"
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_COUNTRY="great-north"
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_FOOD="chips"
     
     stub buildkite-agent \
         "secret get env : echo ${TESTDATA}" \
-        "secret get ANIMAL : echo llama" \
-        "secret get COUNTRY : echo Canada" \
-        "secret get FOOD : echo Poutine"
+        "secret get best : echo llama" \
+        "secret get great-north : echo Canada" \
+        "secret get chips : echo Poutine"
 
     run bash -c "$PWD/hooks/environment"
 
@@ -82,11 +82,11 @@ setup() {
 }
 
 @test "If no key from parameters found in Buildkite secrets the plugin fails" {
-    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_0="ANIMAL"
+    export BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_ANIMAL="best"
    
     stub buildkite-agent \
         "secret get env : echo 'not found'" \
-        "secret get ANIMAL : exit 1" 
+        "secret get best : exit 1" 
 
     run bash -c "$PWD/hooks/environment"
 


### PR DESCRIPTION
This explores adding an optional new `variables` parameter that will read secrets out one by one into an ENV var that is visible in the pipeline.yml.

The syntax and behaviour is modelled after the aws-ssm plugin. It can be helpful in some cases for the ENV vars names to be listed explicitly in the pipeline.yml - it makes their existence more obvious to future maintainers, and it allows the value to be changed to read from different secret keys without mutating the secret value.

This required making both styles optional, so I've taken the controversial approach of removing the default `env` key from the existing "batch" loading syntax. This would mean customers upgrading from v0.1.0 to this might need to add `key: env` to keep the same behaviour. I'm open to alternatives if we don't want a breaking change.

The proposed new syntax:

```yml
steps:
  - command: echo "The content of ANIMAL is \$ANIMAL"
    plugins:
      - cluster-secrets#v0.1.0:
          variables:
            ANIMAL: llamas
            FOO: bar
```