### PR TITLE
chore: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[!IMPORTANT]
-This plugin has been deprecated. Please use the [Secrets Buildkite Plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin)
+**⚠️ Important**
+This plugin has been deprecated, and will no longer receive updates. Please use the [Secrets Buildkite Plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin) in your pipelines.
 
 # Secrets Buildkite Plugin
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Cluster Secrets Buildkite Plugin
+[!IMPORTANT]
+This plugin has been deprecated. Please use the [Secrets Buildkite Plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin)
 
-A Buildkite plugin used to fetch secrets from [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets),
+# Secrets Buildkite Plugin
+
+A Buildkite plugin used to fetch secrets from [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)
 
 ## Storing Secrets
 
 There are two options for storing and fetching secrets.
 
-You can create a secret in your Buildkite cluster(s) from the Buildkite UI following the instructions in the documentation [here](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets#create-a-secret-using-the-buildkite-interface).
+You can create a secret in the Buildkite UI following the instructions in the documentation [here](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets#create-a-secret-using-the-buildkite-interface).
 
 ### One at a time
 
@@ -18,7 +21,7 @@ A `pipeline.yml` like this will read each secret out into a ENV variable:
 steps:
   - command: echo "The content of ANIMAL is \$ANIMAL"
     plugins:
-      - cluster-secrets#v1.0.0:
+      - secrets#v1.0.0:
           variables:
             ANIMAL: llamas
             FOO: bar
@@ -26,7 +29,7 @@ steps:
 
 ### Multiple
 
-Create a single Buildkite secret with one variable per line, encoded as base64 for storage. 
+Create a single Buildkite secret with one variable per line, encoded as base64 for storage.
 
 For example, setting three variables looks like this in a file:
 
@@ -50,7 +53,7 @@ job environment using a pipeline.yml like this:
 steps:
   - command: build.sh
     plugins:
-      - cluster-secrets#v1.0.0:
+      - secrets#v1.0.0:
           env: "llamas"
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A `pipeline.yml` like this will read each secret out into a ENV variable:
 steps:
   - command: echo "The content of ANIMAL is \$ANIMAL"
     plugins:
-      - secrets#v1.0.0:
+      - cluster-secrets#v1.0.0:
           variables:
             ANIMAL: llamas
             FOO: bar
@@ -53,7 +53,7 @@ job environment using a pipeline.yml like this:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v1.0.0:
+      - cluster-secrets#v1.0.0:
           env: "llamas"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 **⚠️ Important**
-This plugin has been deprecated, and will no longer receive updates. Please use the [Secrets Buildkite Plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin) in your pipelines.
+This plugin is no longer maintained and has been deprecated. Secrets are no longer scoped to individual clusters, making this plugin unnecessary. Please use the [Secrets Buildkite Plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin) for managing secrets in your pipelines.
 
 # Secrets Buildkite Plugin
 


### PR DESCRIPTION
With the changes to how Buildkite Secrets are managed in Buildkite, re-releasing the plugin under a more accurate name seems like the correct choice, while deprecating this current plugin. The "new" plugin functions the same, as there is no impact to how secrets are acquired from Buildkite Secrets.

Users wishing to use this plugin should instead use the [Secrets Buildkite plugin](https://github.com/buildkite-plugins/secrets-buildkite-plugin#)