### PR TITLE
Adds automatic retry logic with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A `pipeline.yml` like this will read each secret out into a ENV variable:
 steps:
   - command: echo "The content of ANIMAL is \$ANIMAL"
     plugins:
-      - cluster-secrets#v1.0.0:
+      - cluster-secrets#v1.0.1:
           variables:
             ANIMAL: llamas
             FOO: bar
@@ -53,7 +53,7 @@ job environment using a pipeline.yml like this:
 steps:
   - command: build.sh
     plugins:
-      - cluster-secrets#v1.0.0:
+      - cluster-secrets#v1.0.1:
           env: "llamas"
 ```
 
@@ -66,8 +66,36 @@ The key to fetch multiple from Buildkite secrets
 Specify a dictionary of `key: value` pairs to inject as environment variables, where the key is the name of the
 environment variable to be set, and the value is the Buildkite Secret key.
 
+### `retry-max-attempts` (optional, number, default: 5)
+
+Maximum number of retry attempts for transient failures when fetching secrets (e.g., 5xx server errors, network issues).
+
+### `retry-base-delay` (optional, number, default: 2)
+
+Base delay in seconds for exponential backoff between retry attempts.
+
+## Retry Behavior
+
+This plugin implements automatic retry logic with exponential backoff for secret calls. This will occur for 5xx server errors or any local network issues. If a 4xx code is received, a fast failure will be served.
+
+By default, the base delay will be 2 seconds, with a maximum of 5 retries.
+
+### Example with Custom Retry
+
+```yaml
+steps:
+  - command: build.sh
+    plugins:
+      - cluster-secrets#v1.0.1:
+          env: "llamas"
+          retry-max-attempts: 10
+          retry-base-delay: 2
+```
+
 ## Testing
+
 You can run the tests using `docker-compose`:
+
 ```bash
 docker compose run --rm tests
 ```

--- a/hooks/environment
+++ b/hooks/environment
@@ -15,16 +15,57 @@ calculate_backoff_delay() {
   echo "$TOTAL_DELAY"
 }
 
+buildkite_agent_secret_get_with_retry() {
+  local KEY="$1"
+  local MAX_ATTEMPTS="${BUILDKITE_PLUGIN_CLUSTER_SECRETS_RETRY_MAX_ATTEMPTS:-5}"
+  local BASE_DELAY="${BUILDKITE_PLUGIN_CLUSTER_SECRETS_RETRY_BASE_DELAY:-1}"
+  local ATTEMPT=1
+  local EXIT_CODE
+  local OUTPUT
+
+  while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+    set +e
+    OUTPUT=$(buildkite-agent secret get "${KEY}" 2>&1)
+    EXIT_CODE=$?
+    set -e
+
+    if [ "$EXIT_CODE" -eq 0 ]; then
+      echo "$OUTPUT"
+      return 0
+    fi
+
+    if echo "$OUTPUT" | grep -qiE "(not found|unauthorized|forbidden|bad request)"; then
+      echo "$OUTPUT"
+      return "$EXIT_CODE"
+    fi
+
+    if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+      local TOTAL_DELAY
+      TOTAL_DELAY=$(calculate_backoff_delay "$BASE_DELAY" "$ATTEMPT")
+
+      echo "Failed to fetch secret $KEY (attempt $ATTEMPT/$MAX_ATTEMPTS). Retrying in ${TOTAL_DELAY}s..." >&2
+      echo "Error: $OUTPUT" >&2
+
+      sleep "$TOTAL_DELAY"
+      ATTEMPT=$((ATTEMPT + 1))
+    else
+      echo "Failed to fetch secret $KEY after $MAX_ATTEMPTS attempts" >&2
+      echo "Error: $OUTPUT" >&2
+      return "$EXIT_CODE"
+    fi
+  done
+}
+
 # downloads the secret by provided key using the buildkite-agent secret command
 downloadSecret() {
     local key=$1
 
-    if ! secret=$(buildkite-agent secret get "${key}"); then
+    if ! secret=$(buildkite_agent_secret_get_with_retry "${key}"); then
         echo "not found ${key}"
     else
         echo "${secret}"
     fi
-    
+
 }
 
 # decodes a base64 encoded secret, expects decoded secret to be in the format KEY=value:
@@ -70,13 +111,13 @@ processVariables() {
   for param in ${!BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_*}; do
     key="${param/BUILDKITE_PLUGIN_CLUSTER_SECRETS_VARIABLES_/}"
     path="${!param}"
-    
-    if ! value=$(buildkite-agent secret get "${path}"); then
+
+    if ! value=$(buildkite_agent_secret_get_with_retry "${path}"); then
         echo "⚠️ Unable to find secret at ${path}"
         exit 1
     else
         export "${key}=${value}"
-    fi    
+    fi
   done
 }
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -34,9 +34,7 @@ buildkite_agent_secret_get_with_retry() {
       return 0
     fi
 
-    # TODO: Remove this and restore the line below after testing
-    # if echo "$OUTPUT" | grep -qiE "(not found|unauthorized|forbidden|bad request)"; then
-    if echo "$OUTPUT" | grep -qiE "(unauthorized|forbidden|bad request)"; then
+    if echo "$OUTPUT" | grep -qiE "(not found|unauthorized|forbidden|bad request)"; then
       echo "$OUTPUT"
       return "$EXIT_CODE"
     fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -18,7 +18,7 @@ calculate_backoff_delay() {
 buildkite_agent_secret_get_with_retry() {
   local KEY="$1"
   local MAX_ATTEMPTS="${BUILDKITE_PLUGIN_CLUSTER_SECRETS_RETRY_MAX_ATTEMPTS:-5}"
-  local BASE_DELAY="${BUILDKITE_PLUGIN_CLUSTER_SECRETS_RETRY_BASE_DELAY:-1}"
+  local BASE_DELAY="${BUILDKITE_PLUGIN_CLUSTER_SECRETS_RETRY_BASE_DELAY:-2}"
   local ATTEMPT=1
   local EXIT_CODE
   local OUTPUT

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
+calculate_backoff_delay() {
+  local BASE_DELAY="$1"
+  local ATTEMPT="$2"
+  local DELAY=$((BASE_DELAY * (2 ** (ATTEMPT - 1))))
+  local JITTER=$((RANDOM % (DELAY / 4 + 1)))
+  local TOTAL_DELAY=$((DELAY + JITTER))
+
+  if [ "$TOTAL_DELAY" -gt 60 ]; then
+    TOTAL_DELAY=60
+  fi
+
+  echo "$TOTAL_DELAY"
+}
+
 # downloads the secret by provided key using the buildkite-agent secret command
 downloadSecret() {
     local key=$1

--- a/hooks/environment
+++ b/hooks/environment
@@ -34,7 +34,9 @@ buildkite_agent_secret_get_with_retry() {
       return 0
     fi
 
-    if echo "$OUTPUT" | grep -qiE "(not found|unauthorized|forbidden|bad request)"; then
+    # TODO: Remove this and restore the line below after testing
+    # if echo "$OUTPUT" | grep -qiE "(not found|unauthorized|forbidden|bad request)"; then
+    if echo "$OUTPUT" | grep -qiE "(unauthorized|forbidden|bad request)"; then
       echo "$OUTPUT"
       return "$EXIT_CODE"
     fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,5 +15,5 @@ configuration:
       default: 5
     retry-base-delay:
       type: number
-      default: 1
+      default: 2
 additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,4 +10,10 @@ configuration:
       type: string
     variables:
       type: object
+    retry-max-attempts:
+      type: number
+      default: 5
+    retry-base-delay:
+      type: number
+      default: 1
 additionalProperties: false


### PR DESCRIPTION
Tested this one a pipeline by adding retry on 404 (temporarily), results below.

- Added `buildkite_agent_secret_get_with_retry()` function 
- Added exponential backoff with jitter, capped at 60 seconds per retry
- Fast fail on client errors (4xx)
- Retries on 5xx server errors, network failures, connection timeouts
- Added configurable retry input configuration
- Updated README
- Added tests, all passing
- Bumped to v1.0.1, will cut release upon merge

Here's an example of this working with 404 (which was a temp test and will not retry on 404 now):
```text
🔐 Fetching env secrets from Buildkite secrets
Failed to fetch secret env (attempt 1/5). Retrying in 2s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "env": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=env: 404 Not Found: Secret not found or access denied
Failed to fetch secret env (attempt 2/5). Retrying in 4s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "env": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=env: 404 Not Found: Secret not found or access denied
Failed to fetch secret env (attempt 3/5). Retrying in 9s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "env": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=env: 404 Not Found: Secret not found or access denied
Failed to fetch secret env (attempt 4/5). Retrying in 16s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "env": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=env: 404 Not Found: Secret not found or access denied
Failed to fetch secret env after 5 attempts
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "env": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=env: 404 Not Found: Secret not found or access denied
No secret found at env
Failed to fetch secret AWS_ACCOUNT_I (attempt 1/5). Retrying in 2s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "AWS_ACCOUNT_I": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=AWS_ACCOUNT_I: 404 Not Found: Secret not found or access denied
Failed to fetch secret AWS_ACCOUNT_I (attempt 2/5). Retrying in 4s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "AWS_ACCOUNT_I": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=AWS_ACCOUNT_I: 404 Not Found: Secret not found or access denied
Failed to fetch secret AWS_ACCOUNT_I (attempt 3/5). Retrying in 8s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "AWS_ACCOUNT_I": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=AWS_ACCOUNT_I: 404 Not Found: Secret not found or access denied
Failed to fetch secret AWS_ACCOUNT_I (attempt 4/5). Retrying in 18s...
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "AWS_ACCOUNT_I": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=AWS_ACCOUNT_I: 404 Not Found: Secret not found or access denied
Failed to fetch secret AWS_ACCOUNT_I after 5 attempts
Error: buildkite-agent: fatal: Failed to fetch some secrets:
 - secret "AWS_ACCOUNT_I": GET https://agent.buildkite.com/v3/jobs/<job-uuid>/secrets?key=AWS_ACCOUNT_I: 404 Not Found: Secret not found or access denied
⚠️ Unable to find secret at AWS_ACCOUNT_I
```

